### PR TITLE
Fix bug in MockALE.game_over() for SpaceInvaders train/test

### DIFF
--- a/ctoybox/toybox/toybox/envs/atari/base.py
+++ b/ctoybox/toybox/toybox/envs/atari/base.py
@@ -24,7 +24,7 @@ class MockALE():
 
     def game_over(self):
         # Note that this is to match baselines / atari_py and not what videogames would expect.
-        return self.toybox.get_lives() == 0
+        return self.toybox.get_lives() <= 0
 
     def saveScreenPNG(self, name):
         # Has to be bytes for ALE


### PR DESCRIPTION
This allows SpaceInvaders crashing into the ground to be a true game_over. It was getting caught in an infinite loop because "update_mut" was detecting the end-of-game condition but the ALE wrappers were not resetting like human_play, etc. would.