### PR TITLE
Try upgrading rust?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: rust
 dist: xenial
 
 rust:
-  - 1.31.0
+  - 1.36.0
 
 env:
   global:


### PR DESCRIPTION
This might be the easiest way to get some travis sanity back. We need cargo lock files if we want to keep rustc at an older version.